### PR TITLE
Update README.md with tutorials url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Much of the code is based on https://github.com/xEsteem/WPFordle
 Wordle-onia is a simple application that shows Avalonia running on Desktop, Mobile and Web.
 
 For instructions on how to prepare your system to build for mobile follow the documentation at:
-https://docs.avaloniaui.net/docs/0.10.x/tutorials/developing-for-mobile
+[Android docs](https://docs.avaloniaui.net/docs/guides/platforms/android/) and [iOS docs](https://docs.avaloniaui.net/docs/guides/platforms/ios/)
 
 ![image](https://user-images.githubusercontent.com/4672627/156905488-b8fa7821-e1e7-4251-8f54-2a8d303e4ee9.png)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Much of the code is based on https://github.com/xEsteem/WPFordle
 Wordle-onia is a simple application that shows Avalonia running on Desktop, Mobile and Web.
 
 For instructions on how to prepare your system to build for mobile follow the documentation at:
-https://docs.avaloniaui.net/tutorials/developing-for-mobile
+https://docs.avaloniaui.net/docs/0.10.x/tutorials/developing-for-mobile
 
 ![image](https://user-images.githubusercontent.com/4672627/156905488-b8fa7821-e1e7-4251-8f54-2a8d303e4ee9.png)
 


### PR DESCRIPTION
The URL pointing to the mobile development docs is broken. In this PR i'm pushing a fix to make it point to the 0.10 docs.

Just in case, v11 docs have separate sections such as:
- [Android](https://docs.avaloniaui.net/docs/guides/platforms/android/)
- [iOS](https://docs.avaloniaui.net/docs/guides/platforms/ios/)
- [Web Assembly](https://docs.avaloniaui.net/docs/guides/platforms/how-to-use-web-assembly)